### PR TITLE
Fix task management issues in Vendure Fulfillment plugin

### DIFF
--- a/src/api/tasks.service.ts
+++ b/src/api/tasks.service.ts
@@ -1,158 +1,211 @@
-import {Injectable} from '@nestjs/common';
-import { EventBus, Order, OrderService, RequestContext, TransactionalConnection, OrderState } from '@vendure/core';
-import {LessThanOrEqual, Not, In, Between, FindOperator} from 'typeorm';
-import dayjs from 'dayjs';
-import { TaskMessage } from '../types';
+import { Injectable } from "@nestjs/common";
+import {
+  EventBus,
+  Order,
+  OrderService,
+  RequestContext,
+  TransactionalConnection,
+  OrderState,
+} from "@vendure/core";
+import { LessThanOrEqual, Not, In, Between, FindOperator } from "typeorm";
+import dayjs from "dayjs";
+import { TaskMessage } from "../types";
 
-export const SHOULD_CLEAR_KEY="shouldClearCachedDeliveryRoute"
+export const SHOULD_CLEAR_KEY = "shouldClearCachedDeliveryRoute";
+
 @Injectable()
-export class TasksService{
-    constructor(private conn: TransactionalConnection,
-        private eventBus: EventBus, private orderService: OrderService){
+export class TasksService {
+  constructor(
+    private conn: TransactionalConnection,
+    private eventBus: EventBus,
+    private orderService: OrderService
+  ) {}
 
-    }
+  async getTasks(ctx: RequestContext): Promise<TaskMessage[]> {
+    return [
+      // High priority tasks first
+      ...(await this.getNotDeliveredOrders(ctx)),
+      ...(await this.getNotPreparedForToday(ctx)),
 
-    async getTasks(ctx: RequestContext):Promise<TaskMessage[]>{
-        return [
-            //high priority tasks first
-            ...await this.getNotDeliveredOrder(ctx),
-            ...await this.getNotPreparedWhenDeliveryDateIsToday(ctx),
+      // Then medium priority tasks
+      ...(await this.getNotCollectedOrders(ctx)),
+      ...(await this.getPreparedAndNotOutForDeliveryForToday(ctx)),
 
-            //then medium priority tasks
-            ...await this.getNotCollectedOrders(ctx),
-            ...await this.getPreparedAndNotOutForDeliveryWhenDeliveryDateIsToday(ctx),
+      // Then low priority tasks
+      ...(await this.getNotPreparedForTomorrow(ctx)),
 
-            //then low priority tasks
-            ...await this.getNotPreparedWhenDeliveryDateIsTommorrow(ctx),
+      // Others
+      ...(await this.getAnyOutForDeliveryForToday(ctx)),
+    ];
+  }
 
-            //others
-            ...await this.getAnyOutForDeliveryWhenDeliveryDateIsToday(ctx)
-        ]
-    }
+  async getNotCollectedOrders(ctx: RequestContext): Promise<TaskMessage[]> {
+    const orders = await this.getFilteredOrders(
+      ctx,
+      LessThanOrEqual(dayjs().subtract(2, "days").toDate()),
+      Not("collected"),
+      false
+    );
 
-    async getNotCollectedOrders(ctx: RequestContext):Promise<TaskMessage[]>{
-        const orders= await this.getFilteredOrders(ctx, LessThanOrEqual(dayjs(new Date).subtract(2, 'days').toDate()), Not('collected'), false)
-       
-        return orders.map((order)=>{
-            return {
-                taskName: `Refund Order ${this.getLink(order)} with code "no collection" and place items back on shelf`,
-	            tag: 'Medium Priority',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'success'
-            }
-        })
-    }
+    return orders.map((order) => ({
+      taskName: `Refund Order ${this.getLink(
+        order
+      )} with code "no collection" and place items back on shelf`,
+      tag: "Medium Priority",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "success",
+    }));
+  }
 
-    async getNotDeliveredOrder(ctx: RequestContext):Promise<TaskMessage[]>{
-        const orders= await this.getFilteredOrders(ctx, LessThanOrEqual(dayjs(new Date).subtract(1, 'days').toDate()), Not('Delivered'), true)
-        
-        return orders.map((order)=>{
-            return {
-                taskName: `${this.getLink(order)} passed delivery date, Reshedule Order`,
-	            tag: 'High Priority',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'error'
-            }
-        })
-    }
+  async getNotDeliveredOrders(ctx: RequestContext): Promise<TaskMessage[]> {
+    const orders = await this.getFilteredOrders(
+      ctx,
+      LessThanOrEqual(dayjs().subtract(1, "days").toDate()),
+      Not("Delivered"),
+      true
+    );
 
-    async getNotPreparedWhenDeliveryDateIsToday(ctx: RequestContext):Promise<TaskMessage[]>{
-        const todayStartOfDay= dayjs().startOf('day').toDate();
-        const todayEndOfDay= dayjs().endOf('day').toDate()
-        const orders= await this.getFilteredOrders(ctx, Between(todayStartOfDay, todayEndOfDay), In(['awaitingprep','preparing']))
-        
-        return orders.map((order)=>{
-            return {
-                taskName: `Prepare ${this.getLink(order)} for today`,
-	            tag: 'High Priority',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'error'
-            }
-        })
-    }
+    return orders.map((order) => ({
+      taskName: `${this.getLink(order)} passed delivery date, Reschedule Order`,
+      tag: "High Priority",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "error",
+    }));
+  }
 
-    async getNotPreparedWhenDeliveryDateIsTommorrow(ctx: RequestContext):Promise<TaskMessage[]>{
-        const tomorrow= dayjs().add(1, 'day');
-        const tommorowStartOfDay= tomorrow.startOf('day').toDate();
-        const tomorrowEndOfDay= tomorrow.endOf('day').toDate()
-        const orders= await this.getFilteredOrders(ctx, Between(tommorowStartOfDay, tomorrowEndOfDay), In(['awaitingprep','preparing']) )
-        
-        return orders.map((order)=>{
-            return {
-                taskName: `Prepare ${this.getLink(order)} for tommorow`,
-	            tag: 'Low Priority',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'success'
-            }
-        })
-    }
+  async getNotPreparedForToday(ctx: RequestContext): Promise<TaskMessage[]> {
+    const todayStartOfDay = dayjs().startOf("day").toDate();
+    const todayEndOfDay = dayjs().endOf("day").toDate();
+    const orders = await this.getFilteredOrders(
+      ctx,
+      Between(todayStartOfDay, todayEndOfDay),
+      In(["awaitingprep", "preparing"])
+    );
 
-    async getPreparedAndNotOutForDeliveryWhenDeliveryDateIsToday(ctx: RequestContext):Promise<TaskMessage[]>{
-        const todayStartOfDay= dayjs().startOf('day').toDate()
-        const todayEndOfDay= dayjs().endOf('day').toDate()
-        const orders= await this.getFilteredOrders(ctx, Between(todayStartOfDay, todayEndOfDay), In(['readyfordelivery','prepared']),true )
-        return orders.map((order)=>{
-            return {
-                taskName: `Send ${this.getLink(order)} out for delivery`,
-	            tag: 'Medium Priority',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'success'
-            }
-        })
-    }
+    return orders.map((order) => ({
+      taskName: `Prepare ${this.getLink(order)} for today`,
+      tag: "High Priority",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "error",
+    }));
+  }
 
-    async getAnyOutForDeliveryWhenDeliveryDateIsToday(ctx: RequestContext):Promise<TaskMessage[]>{
-        const todayStartOfDay= dayjs().startOf('day').toDate()
-        const todayEndOfDay= dayjs().endOf('day').toDate()
-        const orders= await this.getFilteredOrders(ctx, Between(todayStartOfDay, todayEndOfDay), 'outfordelivery',true )
-        
-        return orders.map((order)=>{
-            return {
-                taskName: `Finish Daily Deliveries`,
-	            tag: 'In Progress',
-                orderId: order.id,
-                state: order.state,
-                code: order.code,
-                colorType: 'warning'
-            }
-        })
-    }
+  async getNotPreparedForTomorrow(ctx: RequestContext): Promise<TaskMessage[]> {
+    const tomorrow = dayjs().add(1, "day");
+    const tomorrowStartOfDay = tomorrow.startOf("day").toDate();
+    const tomorrowEndOfDay = tomorrow.endOf("day").toDate();
+    const orders = await this.getFilteredOrders(
+      ctx,
+      Between(tomorrowStartOfDay, tomorrowEndOfDay),
+      In(["awaitingprep", "preparing"])
+    );
 
-    private async getFilteredOrders(ctx: RequestContext, dateFilter: FindOperator<Date>, stateFilter: FindOperator<String> | string, isDelivery?:boolean){
-        return await this.conn.getRepository(ctx, Order).
-        createQueryBuilder('order')
-          .select('order.code')
-          .addSelect('order.id')
-          .addSelect('order.state')
-        .leftJoin('order.channels', 'orderChannel')
-        .setFindOptions({where:{
-            customFields:{
-                Delivery_Collection_Date:  dateFilter,
-                ...(isDelivery !== undefined?
-               {Is_Delivery: isDelivery}:{})
-            },
-            state: stateFilter as any,
-            channels:{
-                id: ctx.channelId
-            }
-        }})
-        .andWhere('state NOT IN (:...excludedStates)',{excludedStates: ['Draft','AddingItems','ArraningPayment','PaymentAuthorized','PaymentSettled','Shipped','Delivered', 'Cancelled'] as OrderState[]})
-        .getMany()
-    }
+    return orders.map((order) => ({
+      taskName: `Prepare ${this.getLink(order)} for tomorrow`,
+      tag: "Low Priority",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "success",
+    }));
+  }
 
-    private getLink(order: Order){
-        const link= order.state === 'Draft' ? `/admin/orders/draft/${order.id}` : `/admin/orders/${order.id}`
-        return `<a class="button-ghost" href="${link}" ng-reflect-router-link="./orders,${order.id}" _ngcontent-ng-c518184086>
+  async getPreparedAndNotOutForDeliveryForToday(
+    ctx: RequestContext
+  ): Promise<TaskMessage[]> {
+    const todayStartOfDay = dayjs().startOf("day").toDate();
+    const todayEndOfDay = dayjs().endOf("day").toDate();
+    const orders = await this.getFilteredOrders(
+      ctx,
+      Between(todayStartOfDay, todayEndOfDay),
+      In(["readyfordelivery", "prepared"]),
+      true
+    );
+
+    return orders.map((order) => ({
+      taskName: `Send ${this.getLink(order)} out for delivery`,
+      tag: "Medium Priority",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "success",
+    }));
+  }
+
+  async getAnyOutForDeliveryForToday(
+    ctx: RequestContext
+  ): Promise<TaskMessage[]> {
+    const todayStartOfDay = dayjs().startOf("day").toDate();
+    const todayEndOfDay = dayjs().endOf("day").toDate();
+    const orders = await this.getFilteredOrders(
+      ctx,
+      Between(todayStartOfDay, todayEndOfDay),
+      "outfordelivery",
+      true
+    );
+
+    return orders.map((order) => ({
+      taskName: `Finish Daily Deliveries`,
+      tag: "In Progress",
+      orderId: order.id,
+      state: order.state,
+      code: order.code,
+      colorType: "warning",
+    }));
+  }
+
+  private async getFilteredOrders(
+    ctx: RequestContext,
+    dateFilter: FindOperator<Date>,
+    stateFilter: FindOperator<String> | string,
+    isDelivery?: boolean
+  ) {
+    return await this.conn
+      .getRepository(ctx, Order)
+      .createQueryBuilder("order")
+      .select("order.code")
+      .addSelect("order.id")
+      .addSelect("order.state")
+      .leftJoin("order.channels", "orderChannel")
+      .setFindOptions({
+        where: {
+          customFields: {
+            Delivery_Collection_Date: dateFilter,
+            ...(isDelivery !== undefined ? { Is_Delivery: isDelivery } : {}),
+          },
+          state: stateFilter as any,
+          channels: {
+            id: ctx.channelId,
+          },
+        },
+      })
+      .andWhere("state NOT IN (:...excludedStates)", {
+        excludedStates: [
+          "Draft",
+          "AddingItems",
+          "ArrangingPayment",
+          "PaymentAuthorized",
+          "PaymentSettled",
+          "Shipped",
+          "Delivered",
+          "Cancelled",
+        ] as OrderState[],
+      })
+      .getMany();
+  }
+
+  private getLink(order: Order) {
+    const link =
+      order.state === "Draft"
+        ? `/admin/orders/draft/${order.id}`
+        : `/admin/orders/${order.id}`;
+    return `<a class="button-ghost" href="${link}" ng-reflect-router-link="./orders,${order.id}" _ngcontent-ng-c518184086>
                     <span>${order.code}</span>
                     <clr-icon shape="arrow right" role="none">
                         <svg version="1.1" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" focusable="false" role="img">
@@ -160,7 +213,6 @@ export class TasksService{
                             </path>
                         </svg>
                     </clr-icon>
-                </a>
-                `
-    }
+                </a>`;
+  }
 }


### PR DESCRIPTION
This pull request addresses the following task management issues in the Vendure plugin:

1. Refactored logic to handle orders not collected 2 days after the collection date.
   - Task: Refund Order and place items back on shelf.
   - Priority: Medium

2. Refactored logic to handle orders not delivered 1 day or more after the delivery date.
   - Task: Reschedule Order.
   - Priority: High

3. Refactored logic to handle orders not prepared with the delivery/collection date today.
   - Task: Prepare Order for today.
   - Priority: High

4. Refactored logic to handle orders not prepared with the delivery/collection date tomorrow.
   - Task: Prepare Order for tomorrow.
   - Priority: Low

5. Refactored logic to handle orders that are delivery and have the Delivery_Collection_Date today and are prepared.
   - Task: Send Order out for delivery.
   - Priority: Medium

6. Refactored logic to handle if all delivery orders with a delivery date for today and any are out for delivery.
   - Task: Finish Daily Deliveries.
   - Priority: In Progress

The methods `getNotCollectedOrders`, `getNotDeliveredOrders`, `getNotPreparedForToday`, `getNotPreparedForTomorrow`, `getPreparedAndNotOutForDeliveryForToday`, and `getAnyOutForDeliveryForToday` have been implemented/refactored to handle the respective tasks.

Please review and merge.
